### PR TITLE
Change `name` to `file` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,11 @@ gulp.task('download', function () {
 	const files = [
 		{
             url: 'http://example.com/file.txt',
-            name: 'foo.txt'
+            file: 'foo.txt'
         },
         {
         	url: 'http://example.com/file2.csv',
-        	name: 'data.csv'
+        	file: 'data.csv'
         }
 	];
 
@@ -156,7 +156,7 @@ gulp.task('download', function () {
 
 	return download({
 	    url: 'http://example.com/file.txt',
-	    name: 'foo.txt'
+	    file: 'foo.txt'
 	}, config)
 	.pipe(gulp.dest('build'));
 });


### PR DESCRIPTION
An error as been made in the README, the filename property is not `name` but `file`:
https://github.com/atomicpages/gulp-download2/blob/master/index.js#L39