### PR TITLE
Update type definition for default export.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,4 +18,4 @@ export type Options = SecureContextOptions &
         ci?: boolean;
     };
 
-export default function main(urls: string | string[], options: Options): Stream;
+export default function main(urls: string | string[] | { url: string, file: string }, options: Options): Stream;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,6 @@
 import { SecureContextOptions } from 'tls';
 import { ClientRequestArgs } from 'http';
+import { Stream } from 'stream';
 
 export type Options = SecureContextOptions &
     Pick<
@@ -17,4 +18,4 @@ export type Options = SecureContextOptions &
         ci?: boolean;
     };
 
-export default function main(urls: string | string[], options: Options): void;
+export default function main(urls: string | string[], options: Options): Stream;


### PR DESCRIPTION
It seems like this is causing gulpfile.ts to fail because the expected return type is void which causes build errors and prevents piping etc. Also adds option to include the url/file object option in main.